### PR TITLE
docs: phase 1b — competitive analysis + signature DB eval + recommendations

### DIFF
--- a/docs/research/phase1b-competitive-analysis.md
+++ b/docs/research/phase1b-competitive-analysis.md
@@ -1,0 +1,159 @@
+# TraceFabric — Phase 1b Competitive Analysis
+
+**Scope:** Deterministic-signal extraction across lead-scraping / lead-qualification tools that target local businesses. Goal: confirm where the field invests, where it punts to LLMs, and where TraceFabric's "audited deterministic + LLM cascade" angle fits.
+
+**Date:** 2026-04-30
+**Sources hit:** 14 (cited inline)
+
+---
+
+## 1. Competitive Landscape Summary
+
+The space splits into four archetypes:
+
+1. **Local-business map scrapers** (MapiLeads, Outscraper, Lead Scrape, Local Scraper, Apify Compass actor, Maps Leads) — input is niche+location, they pull GMB/Google Maps + walk the website for emails, phones, socials. **Signal layer is shallow:** business card + scraped contact details. Tech-stack detection is shallow when present at all. Cheap-to-build, race-to-the-bottom pricing (Apify B2B Lead Scraper is $3.90 / 1k results — [apify.com/junipr/b2b-lead-scraper](https://apify.com/junipr/b2b-lead-scraper)).
+2. **B2B contact databases with enrichment layer** (Apollo.io, Cognism, ZoomInfo, Ocean.io) — they own a contact graph, then bolt on technographic + intent. Intent comes from third-party feeds (Bombora, LeadSift). Technographics are licensed or proprietary crawls, never per-request live. ([apollo.io/product/buying-intent](https://www.apollo.io/product/buying-intent), [cognism.com/blog/what-are-technographics](https://www.cognism.com/blog/what-are-technographics)).
+3. **Workflow orchestrators / waterfalls** (Clay.com, Persana AI, PhantomBuster) — don't own data, they route requests through 75-150 third-party providers and let users glue together GPT calls in between. Clay explicitly markets "scrape company data + pass to ChatGPT" ([clay.com/waterfall-enrichment](https://www.clay.com/waterfall-enrichment), [persana.ai](https://persana.ai/)).
+4. **Audit / agency-style tools** (GoHighLevel Prospecting, Website Grader, "AI website audit" Apify actors) — closest semantic neighbors to TraceFabric. GHL generates a marketing-audit PDF per local business covering listings, reviews, online presence gaps ([help.gohighlevel.com](https://help.gohighlevel.com/support/solutions/articles/48001231875-how-to-generate-leads-using-the-highlevel-prospecting-tool)). Quality of signal extraction is thin and the report is the product, not raw scored leads.
+
+**Dominant model:** Hybrid leaning AI-black-box. Persana, Clay, and Apollo openly market "AI lead scoring" with no public scoring rubric. Cognism and Apollo own the deterministic firmographic/technographic layer but it's *their* graph, not extracted live per-URL. Nobody in the surveyed field markets "audited, reproducible, deterministic-first scoring at the per-URL level" — that gap is real.
+
+---
+
+## 2. Signal Taxonomy Table
+
+Cells: `D` = deterministic regex/header/parse; `LLM` = AI-inferred; `3P` = bought from third party; `–` = not offered.
+
+| Signal | MapiLeads | Apollo | Clay | Outscraper | Apify actors | PhantomBuster | Cognism | Ocean.io | Persana | Lead Scrape | GHL | Wappalyzer (lib) |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| GMB / Maps profile (name, addr, hours, rating, reviews) | D | – | D-via-actor | D | D | D | – | – | D | D | D | – |
+| Email harvest (info@, contact@) | D | 3P | D-via-actor | D | D | D | 3P | – | 3P | D | D | – |
+| Phone validation | D | 3P | 3P | D | D | – | D (mobile-verified) | – | 3P | D (98% bounce) | – | – |
+| Social presence (FB/IG/LI/TT) | D | – | D | D | D | D | – | D | – | D | D | – |
+| Tech stack detection | shallow | 3P (own DB) | 3P | – | D (live, B2B Lead Scraper) | – | 3P (own DB) | 3P | 3P | D (shallow) | – | **D (3000+ regex sigs)** |
+| Domain age / WHOIS | – | – | possible-via-script | – | possible | – | – | – | – | – | – | – |
+| Page speed / CWV | – | – | possible-via-script | – | possible | – | – | – | – | – | partial | – |
+| Mobile-friendly | – | – | possible-via-script | – | possible | – | – | – | – | – | partial | – |
+| SSL / HTTPS posture | – | – | possible | – | possible | – | – | – | – | – | – | – |
+| Schema.org / structured data | – | – | – | – | – | – | – | – | – | – | – | – |
+| Outdated JS / vulnerable libs | – | – | – | – | – | – | – | – | – | – | – | partial (Retire.js separately) |
+| Active hiring | – | LLM/3P | 3P | – | – | – | 3P (signals) | – | LLM | – | – | – |
+| Funding events | – | LLM/3P | 3P | – | – | – | 3P | – | LLM | – | – | – |
+| Buying intent (topic) | – | 3P (Bombora/LeadSift) | 3P | – | – | LLM | 3P (Bombora) | – | LLM | – | – | – |
+| Reviews semantic summary | LLM ("Smart Reviews") | – | LLM | – | – | – | – | – | LLM | – | – | – |
+| Lookalike scoring | – | D-vector | – | – | – | – | – | **D (20 filters)** | – | – | – | – |
+| Marketing audit PDF | – | – | – | – | – | – | – | – | – | – | D-template | – |
+| Custom scoring rubric (audited) | – | opaque | user-built | – | – | – | opaque | – | opaque | – | template | – |
+
+Key observations:
+- **Domain age, page speed, mobile-friendly, SSL grade, schema markup, vulnerable JS** — **nobody** in the lead-tool field surfaces these as first-class signals. They sit in the SEO-audit world ([thrillxdesign.com](https://thrillxdesign.com/the-ultimate-website-audit-checklist/), [website.grader.com](https://website.grader.com/)) but aren't wired into a lead-scoring pipeline.
+- **Tech-stack detection** is the only deterministic signal everyone agrees matters — and most of them buy or license it rather than running it live per-request.
+- Clay and Apify let users *script* deterministic checks but ship nothing curated by default ([clay.com/waterfall-enrichment](https://www.clay.com/waterfall-enrichment), [use-apify.com/docs/best-apify-actors/best-lead-generation-actors](https://use-apify.com/docs/best-apify-actors/best-lead-generation-actors)).
+
+---
+
+## 3. Deterministic-Only Signal Field — Deep Dive
+
+What's actually cheap and reliable to extract per-URL, with no LLM tokens:
+
+**Header / response layer:**
+- `Server`, `X-Powered-By`, `Set-Cookie` patterns → CMS, framework, hosting
+- HTTP status, redirect chain → site health
+- TLS cert issuer + expiry → trust signal
+- HTTP/2 / HTTP/3 support → modernity proxy
+
+**HTML / DOM layer:**
+- `<meta generator>` → CMS confirmation
+- `<script src=…>` paths → JS framework, analytics, chat widget, booking widget
+- `<link rel=…>` → favicons, sitemap, manifest (PWA)
+- Schema.org JSON-LD blocks → LocalBusiness, Restaurant, Service offerings
+- Open Graph + Twitter card presence → marketing maturity
+- Form fields + `action` URLs → CRM/lead-capture tool fingerprint
+- Embedded social handles (regex `instagram\.com/[\w.]+`) → social presence depth
+
+**Behavioral / external layer (still deterministic):**
+- WHOIS lookup → domain age, registrar, expiry runway ([whois.whoisxmlapi.com/domain-age-checker](https://whois.whoisxmlapi.com/domain-age-checker))
+- DNS records → MX provider (Google Workspace vs hosted), SPF/DKIM presence (email maturity), CAA records
+- PageSpeed Insights API → Core Web Vitals (free, deterministic given URL)
+- Mobile-friendly test → Google's free API
+- robots.txt + sitemap.xml → SEO posture
+- HTTPS-only redirect → security posture
+
+**Content-derived (regex-only, no LLM):**
+- Phone number extraction (libphonenumber)
+- Email harvesting (RFC patterns)
+- Address extraction (postal patterns + city/state lists)
+- Booking-link detection (Calendly, Square, OpenTable URLs)
+- Payment-processor fingerprint (Stripe, Square, PayPal script srcs)
+
+The Wappalyzer fingerprint format — "categories, cookies, dom, js, headers, html, scripts, scriptSrc, meta, implies" — is the canonical schema for this whole layer ([github.com/enthec/webappanalyzer](https://github.com/enthec/webappanalyzer)). Treat it as the de facto standard.
+
+**Cost-per-URL (rough order):** WHOIS ~$0.0001, PSI ~free, fetch + parse + signature match ~$0.0005 in compute. **Total deterministic Tier 0 < $0.001 per URL.** A Gemini Flash call to the same content is ~$0.005-0.02. That's a 5-20x cost gap that nobody is currently exploiting as a marketed product.
+
+---
+
+## 4. Signature DB Landscape
+
+**Wappalyzer (original)** — went private August 2023. The pre-private MIT-licensed snapshot lives at [github.com/dochne/wappalyzer](https://github.com/dochne/wappalyzer) and [github.com/Lissy93/wapalyzer](https://github.com/Lissy93/wapalyzer). Useful as a baseline but freezing in time.
+
+**Enthec/webappanalyzer** — actively-maintained fork, **GPLv3 licensed**, explicit commitment never to privatize ([github.com/enthec/webappanalyzer](https://github.com/enthec/webappanalyzer)). 3000+ technology signatures organized as JSON regex bundles in `src/technologies/[a-z].json`. Same fingerprint structure as the original. **GPLv3 is the gotcha** — vendoring it forces TraceFabric (or at least the sig-matching component) to be GPLv3 too. If TraceFabric is closed-source SaaS this is workable (no distribution = no GPL trigger), but if you ship a CLI or self-hosted edition, GPL contamination is a real concern.
+
+**Implementations to vendor (not rebuild):**
+- [projectdiscovery/wappalyzergo](https://github.com/projectdiscovery/wappalyzergo) — high-perf Go port, MIT, used by ProjectDiscovery security tools
+- [PigeonSec/py-wappalyzer](https://github.com/PigeonSec/py-wappalyzer) — Python lib using enthec sigs, parses HAR files (great for your Rust scraper → Python evaluator flow)
+- [rverton/webanalyze](https://pkg.go.dev/github.com/rverton/webanalyze) — Go port, used widely
+- Wappalyzer-next CLI — Python CLI on enthec sigs
+
+**BuiltWith** — 250M+ websites in their DB, free API is rate-limited to 1 req/sec and only returns category counts ([api.builtwith.com/free-api](https://api.builtwith.com/free-api)). Paid tiers are credit-based; bulk lookups burn credits fast ([kb.builtwith.com](https://kb.builtwith.com/general-questions/plans-and-pricing-explained/)). Not viable for live per-request use unless you cache aggressively. Useful for *cohort* lookups ("all Shopify stores in Austin") but that's a different product.
+
+**Retire.js** — manually-maintained JSON of vulnerable JS library signatures ([github.com/retirejs/retire.js](https://github.com/RetireJS/retire.js/), `repository/jsrepository.json`). Apache 2.0. Detects by URL, filename, content, or hash. Vendor this directly for the "outdated JS" signal — nobody in the lead-tool space surfaces it and it's a strong "this site is decaying" indicator.
+
+**Other open alternatives:** Stackcrawler ($9/mo, paid), urlscan.io (free for non-commercial, has its own fingerprint engine). No serious permissive-license alternative to Wappalyzer's coverage exists — the GPLv3 enthec fork is effectively the only game in town.
+
+**Recommendation:** Vendor Enthec sigs in a process-isolated component (Python evaluator subprocess, AGPL/GPL boundary clean), keep TraceFabric core MIT/proprietary. Layer Retire.js sigs alongside. Add custom curated sigs for local-business-specific tools (booking systems, POS systems, restaurant CMSes) where Wappalyzer is weak.
+
+---
+
+## 5. Differentiation Angle
+
+**The gap:** Every competitor either (a) sells a contact graph with opaque scoring (Apollo, Cognism), (b) sells raw scraped business cards with no scoring (Outscraper, MapiLeads, Lead Scrape), or (c) sells a workflow canvas where the user has to build their own scoring (Clay, Persana). **No one ships a curated, audited, deterministic-first scoring pipeline that runs live per-URL and exposes the rubric.**
+
+**TraceFabric's defensible play — three claims, in priority order:**
+
+1. **"Audited deterministic Tier 0 → LLM cascade only when needed"** — every score has a reproducible trace (which signature matched, which header value, which regex hit). Competitors hide this. This matters for agencies that need to *justify* a lead score to a client.
+2. **"Local-business signal coverage that generic tech-stack DBs miss"** — booking systems, restaurant POS, salon software, contractor CRMs. Wappalyzer is strong on dev tooling, weak on local-biz SaaS. Curate this gap.
+3. **"5-20x cheaper at scale than LLM-first scorers"** — concrete unit-economics story for users running 10k+ URLs/month. Persana and Clay burn tokens on every lead; TraceFabric only spends tokens when deterministic signals are inconclusive.
+
+**Risks to flag:**
+- Clay can imitate this in a week if they ship a "deterministic block library" — they have the user base and the canvas.
+- Apollo could turn on per-URL live scoring if they wanted; they're holding back because contact-DB margins are better.
+- The "audited rubric" angle only matters to buyers who care about explainability — agencies, RegTech-adjacent verticals. Mass-market SDRs don't care.
+
+**Build-don't-vendor calls:**
+- Build: curated local-biz SaaS sigs, the deterministic scoring engine, the audit-trail UI.
+- Vendor: Enthec Wappalyzer sigs (process-isolated for license hygiene), Retire.js sigs, Google PSI/Mobile-Friendly APIs, libphonenumber, public WHOIS.
+
+---
+
+## Sources
+
+1. [mapileads.com](https://mapileads.com/)
+2. [apollo.io/product/buying-intent](https://www.apollo.io/product/buying-intent)
+3. [cognism.com — what are technographics](https://www.cognism.com/blog/what-are-technographics)
+4. [cognism.com/signal-data](https://www.cognism.com/signal-data)
+5. [clay.com/waterfall-enrichment](https://www.clay.com/waterfall-enrichment)
+6. [outscraper.com/google-maps-scraper](https://outscraper.com/google-maps-scraper/)
+7. [apify.com/junipr/b2b-lead-scraper](https://apify.com/junipr/b2b-lead-scraper)
+8. [use-apify.com — best lead generation actors](https://use-apify.com/docs/best-apify-actors/best-lead-generation-actors)
+9. [phantombuster — Data Scraping Crawler](https://support.phantombuster.com/hc/en-us/articles/26971188404370-How-to-use-the-Data-Scraping-Crawler)
+10. [ocean.io/api](https://www.ocean.io/api)
+11. [persana.ai — lead enrichment](https://persana.ai/blogs/what-is-lead-enrichment-in-sales)
+12. [leadscrape.com](https://www.leadscrape.com/)
+13. [help.gohighlevel.com — Prospecting Tool](https://help.gohighlevel.com/support/solutions/articles/48001231875-how-to-generate-leads-using-the-highlevel-prospecting-tool)
+14. [github.com/enthec/webappanalyzer](https://github.com/enthec/webappanalyzer)
+15. [github.com/RetireJS/retire.js](https://github.com/RetireJS/retire.js/)
+16. [api.builtwith.com/free-api](https://api.builtwith.com/free-api)
+17. [kb.builtwith.com — plans](https://kb.builtwith.com/general-questions/plans-and-pricing-explained/)
+18. [github.com/projectdiscovery/wappalyzergo](https://github.com/projectdiscovery/wappalyzergo)
+19. [github.com/dochne/wappalyzer (pre-private snapshot)](https://github.com/dochne/wappalyzer)
+20. [galadon.com — Wappalyzer alternatives](https://galadon.com/wappalyzer-alternatives)

--- a/docs/research/phase1b-recommendations.md
+++ b/docs/research/phase1b-recommendations.md
@@ -1,0 +1,197 @@
+# Phase 1b — Recommendations Synthesis
+
+> Concrete answers to decisions #3 and #4 from `phase1-recon.md`, grounded in `phase1b-competitive-analysis.md` and `phase1b-signature-db-evaluation.md`. Read this if you don't have time to read the full research docs.
+
+## Context
+
+Phase 1 recon flagged four open decisions before Phase 2 starts. While Tee was traveling, I executed two parallel research streams:
+
+1. **Competitive landscape** — what 11 lead-tool competitors actually do for deterministic signal extraction (`phase1b-competitive-analysis.md`)
+2. **Signature DB evaluation** — open + commercial signature databases for tech fingerprinting (`phase1b-signature-db-evaluation.md`)
+
+This doc is the synthesis. Tier priority (#1) and labeled URL set (#2) are still pending Tee's input — out of scope for this doc.
+
+---
+
+## Headline finding from competitive research
+
+**Nobody in the surveyed field markets "audited, reproducible, deterministic-first scoring at the per-URL level."** The space is dominated by:
+
+- Contact databases with opaque scoring (Apollo, Cognism, ZoomInfo)
+- Raw scrape dumps with no scoring (Outscraper, MapiLeads, Lead Scrape)
+- Workflow canvases that punt scoring to the user (Clay, Persana, PhantomBuster)
+- Agency audit-PDF generators (GoHighLevel, Website Grader)
+
+**The gap is real and TraceFabric's positioning fits it directly.** This finding strengthens the case for the auditable-rubric direction across both decisions below.
+
+Concrete unit-economics angle worth noting: **deterministic Tier 0 costs ~$0.001/URL vs LLM-first scorers at ~$0.005-0.02/URL**. That 5-20x gap is a real story for buyers running 10k+ URLs/month.
+
+---
+
+## Decision #3 — Signature pack source
+
+### Recommendation: **Hybrid (Option C from the recon doc)**
+
+Three components, in order of effort:
+
+#### Component A: Vendor `enthec/webappanalyzer` (filtered)
+- GPL-3.0, last push 2026-04-17, ~3,000 signatures, formal `schema.json`
+- Filter to ~700 signatures whose categories intersect our use case (CMS, ecommerce, analytics, marketing automation, payment processors, page builders, live chat, CRM, appointment scheduling)
+- Strip the 2,300 signatures we don't need (devops, security tools, IoT, etc.) → 3.4 MB → ~600 KB
+- Pin to a snapshot, monthly auto-PR refresh via GitHub Action, human reviews diff
+- **License hygiene:** keep the signature data isolated under `logic-engine/signals/wappalyzer_pack/`, ship enthec's `LICENSE` verbatim, link to source in README. Conservative posture treats data as separate from code; for closed-source SaaS the SaaS-loophole means no GPL distribution event triggers (confirm with counsel before any self-hosted shipping).
+
+#### Component B: Vendor `retire.js` signatures (Apache-2.0)
+- 4.1k stars, last push 2026-04-24, no GPL constraints
+- Detects outdated/vulnerable JS libraries → strong "this site is decaying" signal that **no competitor surfaces** as a lead-quality marker
+- Drop alongside Wappalyzer pack as `logic-engine/signals/retirejs_pack/`
+
+#### Component C: Curate local-biz overlay (the differentiation)
+- Wappalyzer is **strong on dev tooling, weak on local-biz SaaS**
+- Confirmed gaps: **Booksy, Mindbody** (the signature DB research verified these are missing or weak)
+- Curate ~30-50 signatures from scratch covering:
+  - Booking systems: Booksy, Mindbody, Vagaro, Schedulicity, Square Appointments (verify), Setmore, Acuity (verify), 10to8
+  - Restaurant POS / ordering: Toast Online Ordering, ChowNow, Square for Restaurants, Resy (front of house signals), OpenTable widgets
+  - Salon / spa software: Boulevard, Phorest, Rosy, Mangomint
+  - Contractor CRMs: ServiceTitan, Housecall Pro, Jobber, FieldEdge
+  - Local marketing tools: BirdEye widget, Podium widget, NiceJob review widget
+- Store as `logic-engine/signals/local_biz_pack/*.json` using the same Wappalyzer schema (so the same matcher engine handles all three packs)
+
+#### Component D: Free remote APIs to plug in (orthogonal axes)
+- **Google PageSpeed Insights v5** — 25k req/day per GCP project, full Lighthouse JSON. Free CWV, perf, SEO, accessibility scoring.
+- **Mozilla Observatory v2** — no auth, 1 scan/host/min, A+→F security grade (HSTS, CSP, etc.)
+- These run async after Tier 0 fingerprint match; results merge into `deterministic_evidence`
+
+#### What to skip
+- **BuiltWith** — $295-995/mo, free tier returns only category counts. Skip until paying customers.
+- **SecurityHeaders.com API** — Snyk shutting down April 2026.
+- **Hardenize** — no public free programmatic endpoint post-Red Sift acquisition.
+- **CERN-CERT/wad** — last push Sept 2023, dead.
+- **Building from scratch (Option B in recon)** — ruled out. 3,000+ signature-weeks of curation when 80% of value is already in `enthec`. Reserve curation effort for the local-biz overlay where Wappalyzer is genuinely thin.
+
+### Why hybrid, not pure-vendor or pure-curate
+
+- Pure-vendor (enthec only): comprehensive day-one but misses the local-biz layer that's our differentiation. Also, the GPL surface is bigger than necessary.
+- Pure-curate (Option B): weeks of work to reach 700 sigs, fragile, reinventing.
+- Hybrid: 80% comprehensive coverage from enthec, 100% relevance for our niche from the local-biz overlay, license risk minimized by isolating GPL'd component.
+
+### Implementation sketch
+
+```
+logic-engine/
+  signals/
+    wappalyzer_pack/         # vendored, GPL'd, isolated
+      LICENSE                # enthec's GPL-3.0
+      filter_script.py       # one-time + scheduled refresh
+      data/[a-z].json        # filtered signatures
+    retirejs_pack/           # vendored, Apache-2.0
+      LICENSE
+      data/jsrepository.json
+    local_biz_pack/          # our curation, MIT
+      booking.json
+      restaurant_pos.json
+      salon_spa.json
+      contractor_crm.json
+      review_widgets.json
+    matcher.py               # shared engine, reads all three packs
+    remote_apis/
+      psi.py                 # PageSpeed Insights wrapper
+      observatory.py         # Mozilla Observatory wrapper
+```
+
+`matcher.detect(raw_lead) → list[Detection]` is the public API. Each `Detection` carries `(name, category, source_pack, signature_id, confidence, matched_field, matched_value)` so every score is traceable — that's the audit trail that nobody else ships.
+
+---
+
+## Decision #4 — Weights source
+
+### Recommendation: **YAML now, XGBoost later (parallel, not replacement)**
+
+#### Why YAML first
+
+1. **No labels yet.** XGBoost needs a teacher-labeled training set. Tee's "20 good + 20 bad" benchmark hasn't been collected, and even when it lands, that's a precision/recall validation set, not a training set. XGBoost typically wants 500+ rows minimum. We're 1-2 months from having that.
+2. **The auditable-rubric IS the differentiation** per competitive research. Persana, Clay, Apollo all use opaque scoring. A YAML rubric you can show a client ("here's why this lead scored 0.78, with the 6 signals that contributed") is the moat.
+3. **Lower regression risk.** YAML weights are reviewable in PR, easy to roll back, easy to tune per campaign. ML drift is invisible.
+4. **Existing roadmap aligns.** Project Phase 5 already plans XGBoost integration after teacher-label dataset saturates. YAML is the bridge that fills the next 2-3 months.
+
+#### Recommended structure
+
+```yaml
+# logic-engine/campaigns/website_modernization.weights.yml
+version: 1
+campaign: website_modernization
+required_signals:
+  is_real_business: 1.0          # binary gate, must pass
+weights:
+  # Signal name (matches matcher.detect output)
+  : weight (sum need not = 1.0)
+  cms.wordpress: 0.15            # WordPress + outdated = prime modernization target
+  signal.outdated_jquery: 0.20   # via Retire.js
+  signal.no_mobile_viewport: 0.25
+  signal.no_https: 0.20
+  signal.poor_psi_mobile: 0.15   # via PSI
+  signal.stale_copyright_3y: 0.10
+  signal.no_schema_markup: 0.05
+  # ...
+ceilings:
+  total_score: 1.0               # cap
+gates:
+  reject_if:
+    - signal.is_parked_domain
+    - signal.builder_squarespace_modern  # already on a modern stack
+```
+
+Per-campaign YAML files. Loaded at startup. Each signal is documented and traceable. Adding a new signal = add a row. Tweaking a weight = edit a number. Diff lives in git.
+
+#### Migration path to XGBoost
+
+Once we have ≥500 teacher-labeled rows (Tier 2 outputs serve as the labels per the No-Drop strategy):
+
+1. Train XGBoost on the same `signal_name → value` features the YAML rubric uses
+2. Ship XGBoost output as a **parallel signal** alongside the YAML score, not as a replacement
+3. Compare YAML score vs XGBoost score per lead, log disagreement
+4. After 2-3 weeks of comparison, decide: blend (e.g., 0.7 * YAML + 0.3 * XGBoost), promote XGBoost, or keep YAML if it's still winning
+5. **Never drop the YAML rubric entirely** — it's the explainability layer for client-facing scoring
+
+This preserves the audit story even after XGBoost is live: every lead gets a YAML rubric breakdown AND an XGBoost score, and the discrepancy itself is a useful signal for QA.
+
+#### Why not "just XGBoost when we have labels"
+
+The competitive research is clear: opaque scoring is what everyone else does. The moment TraceFabric becomes a black-box scorer, we lose the agency-friendly differentiation. The YAML rubric stays as the user-facing artifact even when XGBoost is the production scorer — XGBoost just becomes one input.
+
+---
+
+## What we still need from Tee (decisions #1 and #2)
+
+1. **Tier priority confirm** for Phase 2 signal modules (default: S-tier first per recon doc)
+2. **20 known-good + 20 known-bad URLs** for the validation benchmark (Tee said this comes later)
+
+Phase 2 implementation can begin on signature pack vendoring + matcher engine + YAML weights schema in parallel — all of which is decision-independent. The labeled benchmark and tier confirm only block the *last mile* of Phase 2 (validation + tuning).
+
+---
+
+## Suggested Phase 2 starter scope (for when Tee greenlights)
+
+**Sprint 1 (1-2 days):**
+- Vendor enthec sigs with filter script
+- Vendor retire.js sigs
+- Build `signals/matcher.py` that reads both packs and returns `Detection[]` against a `RawLead` dict
+- Wire matcher into `gatekeeper.py` so detections land in `heuristic_flags["technologies"]`
+- Snapshot regression tests with ~10 fixture HTMLs (Squarespace, Shopify, WordPress, HubSpot, Calendly, Mailchimp, Stripe, Cloudflare)
+
+**Sprint 2 (2-3 days):**
+- Curate first 30 local-biz signatures (Booksy, Mindbody, Vagaro, Toast, Square Appointments, ServiceTitan, Housecall Pro, BirdEye widget, Podium widget, etc.)
+- Wire PSI + Observatory remote APIs as background fetchers
+- Define YAML weight schema and migrate the existing `deterministic_evaluator.py` scoring formula into it
+- One YAML file per existing campaign (`website_modernization`, `voice_ai_agent`, `smma`)
+
+**Sprint 3 (1 day):**
+- Run full pipeline against Tee's 20-good / 20-bad benchmark when delivered
+- Tune YAML weights based on precision/recall per signal
+- Document tuning rationale per change
+
+Ship as one PR per sprint, all behind a `signals_v2` feature flag in `runtime.py` so the existing pipeline is untouched until we explicitly cut over.
+
+---
+
+*Synthesis written 2026-04-30 from the two research docs in this folder. Recommendations are mine; final calls are Tee's.*

--- a/docs/research/phase1b-signature-db-evaluation.md
+++ b/docs/research/phase1b-signature-db-evaluation.md
@@ -1,0 +1,176 @@
+# Phase 1b — Signature Database Evaluation for Tier 0 Deterministic Fingerprinting
+
+> Goal: decide whether to vendor an existing tech-fingerprint signature pack (Wappalyzer-class) or hand-curate one for `logic-engine/signals/`. Tier 0 must run zero LLM calls.
+
+## TL;DR
+
+Vendor `enthec/webappanalyzer` (the de-facto living Wappalyzer fork) as a stripped, pinned snapshot bundled under `logic-engine/signals/wappalyzer_pack/`, and add a thin hand-curated overlay for the niche local-biz tools Wappalyzer doesn't cover (notably **Booksy**, plus a few Mindbody/booking edge cases). This is **Option C — Hybrid**, and the data below supports it. Reasoning: enthec is GPL-3.0, actively maintained (last push 2026-04-17, 492 stars), uses a clean documented JSON schema, ships ~3.4 MB across 27 alphabetic files, and already covers Squarespace, Shopify, Wix, HubSpot, Salesforce, Calendly, Vagaro, Mailchimp, Marketo, VWO, Vercel, Cloudflare, Stripe, etc. Hand-curating from scratch buys nothing.
+
+Pair the local pack with two free remote APIs for what signature matching can't tell you: **Google PageSpeed Insights API** (25k req/day per project, free, returns a full Lighthouse report including modern-web SEO/perf/a11y scoring) and **Mozilla HTTP Observatory v2 API** (no auth, no quota, security header grade). Skip SecurityHeaders.com (Snyk announced its API shuts down April 2026), skip BuiltWith (paid, $295–$995/mo), skip Hardenize as a runtime dep (acquired by Red Sift, no public free API for bulk).
+
+---
+
+## 1. Open-source signature DB landscape
+
+| Project | Repo | License | Last push | Signatures | Schema | Notes |
+|---|---|---|---|---|---|---|
+| **enthec/webappanalyzer** | github.com/enthec/webappanalyzer | GPL-3.0 | 2026-04-17 | ~3,000 across 27 JSON files (~3.4 MB) | JSON, formal `schema.json` | Stated successor to closed-source Wappalyzer, "committed not to set this repo private". Actively maintained, 492 stars. |
+| **HTTPArchive/wappalyzer** | github.com/HTTPArchive/wappalyzer | GPL-3.0 | 2026-04-27 | Same starting corpus as enthec, slightly diverged | JSON, same schema | Maintained for the monthly HTTP Archive crawl. 116 stars. Less community traction than enthec but more institutional backing. |
+| **WhatWeb** | github.com/urbanadventurer/WhatWeb | GPLv2 | 2026-04-03 | ~1,800 plugins | Ruby `.rb` files | Plugins are executable Ruby, not data. Unusable as a Python-importable corpus without rewriting. Good as a cross-check for niche detections. |
+| **retire.js** | github.com/RetireJS/retire.js | Apache-2.0 | 2026-04-24 | Hundreds of vulnerable JS-lib signatures | JSON repository (`jsrepository.json`) | Apache-2.0 = permissive, no copyleft. Perfect "outdated/needs-modernization" signal — pair it with the Wappalyzer pack. |
+| **CERN-CERT/WAD** | github.com/CERN-CERT/WAD | GPL-3.0 | 2023-09-01 | ~1,500 (legacy Wappalyzer fork) | JSON (legacy Wappalyzer format) | **Stale** — last push Sept 2023. Skip. |
+| **PigeonSec/py-wappalyzer** | github.com/PigeonSec/py-wappalyzer | unspecified | active | downloads enthec data at runtime | Python lib | Not a signature DB itself. Useful as reference implementation showing how to load enthec JSON in Python 3.8+. |
+| **chorsley/python-Wappalyzer** | pypi.org/project/python-Wappalyzer | MIT | archived | uses old Wappalyzer JSON | Python lib | Original Python wrapper, archived/unmaintained, no PyPI release in 12+ months. Skip the lib but the loader code is a 200-line reference. |
+
+Wappalyzer JSON signature schema (per `schema.json`):
+
+- **Required:** `cats[]` (numeric category IDs), `website`
+- **Detectors:** `cookies`, `dom`, `dns`, `headers`, `html`, `text`, `css`, `robots`, `meta`, `probe`, `scriptSrc`, `scripts`, `url`, `xhr`, `js`, `certIssuer`
+- **Metadata:** `description`, `icon`, `cpe`, `oss`, `saas`, `pricing[]` (low/mid/high/freemium/poa/payg/onetime/recurring)
+- **Relationships:** `implies`, `requires`, `requiresCategory`, `excludes`
+
+All detector values are JS-style regex strings with optional `\;version:\1` and `\;confidence:50` suffixes. Trivially portable to Python `re` — strip the `\;` annotations during load. 111 categories cover everything we care about (CMS=1, Ecommerce=6, Analytics=10, CDN=31, Marketing automation=32, Payment processors=41, Page builders=51, Live chat=52, CRM=53, Appointment scheduling=72, A/B Testing=74, Email=75, Hosting=88, Reservations & delivery=93, Form builders=110, etc.).
+
+Sample signature (HubSpot, from `h.json`):
+
+```json
+"HubSpot": {
+  "cats": [32],
+  "scriptSrc": ["\\.hs-scripts\\.com/"],
+  "html": ["<!-- Start of Async HubSpot"],
+  "js": {"_hsq": "", "hubspot": ""},
+  "dns": {"TXT": ["hubspotemail.net", "hubspot-domain-verification"]},
+  "saas": true,
+  "pricing": ["recurring", "high"]
+}
+```
+
+The `pricing` array is gold for lead qualification — it tells us the prospect's stack is "high-recurring" (HubSpot Pro) vs "freemium" (Calendly free), which directly maps to budget signals.
+
+## 2. Commercial alternatives
+
+| Vendor | Free tier | Paid | Bulk license | Verdict |
+|---|---|---|---|---|
+| **BuiltWith** | Single-domain lookup via web UI; Free API rate-limited to 1 rps and only returns counts/categories | List-building $295/mo, Pro $495/mo, top tier ~$995/mo | Snowflake/Databricks/Redshift/BigQuery datasets (enterprise pricing, not published) | Overkill at our stage. Massive coverage but $3.5–12k/yr is wasted spend until we have paying customers. Worth revisiting at Tier 1 enrichment if we want firmographics. |
+| **Wappalyzer Pro** (the closed-source one) | None for API | API plans start $250+/mo | Enterprise | Skip — same data as enthec but paid. |
+| **WhatRuns / SimilarTech** | Limited free | Mid-3-figures monthly | Available | Skip for same reason. |
+
+## 3. Free remote APIs worth wiring in
+
+| API | Endpoint | Auth | Quota | What it gives us |
+|---|---|---|---|---|
+| **Google PageSpeed Insights v5** | `https://www.googleapis.com/pagespeedonline/v5/runPagespeed` | API key (free) | 25,000 req/day per GCP project, 400 per 100 sec | Full Lighthouse JSON: performance score, SEO score, a11y score, best-practices score, Core Web Vitals (LCP, CLS, INP, FCP, TTFB), opportunities, and **detected technologies** (Lighthouse runs its own light fingerprinter). High-signal "needs modernization" axis. |
+| **Mozilla HTTP Observatory v2** | `POST https://observatory-api.mdn.mozilla.net/api/v2/scan?host=<HOST>` | None | 1 scan/host/min, cached otherwise | Letter grade A+→F + score 0–145 on security headers (CSP, HSTS, X-Frame-Options, Referrer-Policy, etc.). Fast, free, no key. Drop-in proxy for SecurityHeaders.com. |
+| **CrUX History API** | `https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord` | API key | Generous free | Real-world Core Web Vitals from Chrome telemetry. Use only when PSI data is thin. |
+| **SecurityHeaders.com API** | `api.securityheaders.com` | Paid sub | n/a | **Skip** — Snyk announced API shutdown April 2026. |
+| **Hardenize** | private | n/a | n/a | **Skip** — post-Red Sift acquisition there's no public free programmatic endpoint. |
+
+## 4. Per-signal-class coverage matrix
+
+Coverage check against enthec/webappanalyzer at the categories we care about:
+
+| Signal class | Enthec coverage | Examples confirmed | Gap fill needed? |
+|---|---|---|---|
+| CMS | Excellent | WordPress, Squarespace (cat 1), Wix, Joomla, Drupal, Ghost, Webflow | No |
+| Page builders | Excellent | Elementor, Divi, Beaver Builder, Webflow, Carrd (cat 51) | No |
+| E-commerce | Excellent | Shopify, WooCommerce, BigCommerce, Magento (cat 6) | No |
+| Payment processors | Good | Stripe, PayPal, Square, Klarna (cat 41) | No |
+| Analytics | Excellent | GA4, Mixpanel, Segment, Amplitude, Heap, Plausible, Fathom (cat 10) | No |
+| CRM | Good | HubSpot, Salesforce, Pipedrive, ActiveCampaign (cat 53) | No |
+| Email/Marketing automation | Good | Mailchimp, Klaviyo, Marketo, Pardot, Drip (cat 32, 75) | No |
+| Booking widgets | **Mixed** | Calendly ✓, Acuity ✓, Vagaro ✓, Square Appointments ✓, Mindbody ✗, **Booksy ✗** | **Yes — add Booksy and verify Mindbody** |
+| Live chat | Excellent | Intercom, Drift, Tidio, LiveChat, Zendesk Chat, Crisp (cat 52) | No |
+| A/B testing | Good | Optimizely, VWO, Google Optimize (cat 74) | No |
+| Hosting/CDN | Excellent | Cloudflare, Vercel, Netlify, AWS CloudFront, Fastly (cat 31, 62, 88) | No |
+| Outdated JS libs | Use **retire.js** (separate Apache-2.0 corpus) | jQuery <3.5, Angular 1.x, Bootstrap 3, etc. | retire.js fills this |
+| Security headers | Use **Mozilla Observatory** (remote API) | CSP, HSTS, etc. | Observatory fills this |
+| Performance | Use **PSI/Lighthouse** (remote API) | LCP, CLS, INP | PSI fills this |
+
+Direct verification (raw entries pulled from `enthec/webappanalyzer` main):
+
+- **Calendly** → `cats:[72]`, `scriptSrc: ["assets\\.calendly\\.com/"]`, `js: {"Calendly.showPopupWidget": ""}` — present, strong.
+- **Vagaro** → `cats:[72]`, `scriptSrc: ["www\\.schedulicity\\.com"]` — present (schedulicity is now a Vagaro brand).
+- **Vercel** → `cats:[62]`, `headers: {x-vercel-id, x-vercel-cache, ...}` — present, strong.
+- **VWO** → `cats:[10,74]`, `scriptSrc: ["dev\\.visualwebsiteoptimizer\\.com/"]` — present.
+- **Booksy** → not present in `b.json`. **Hand-curate this one.** Easy: `*.booksy.com` script, `booksy-widget` class, "powered by Booksy" string.
+- **Mindbody** → not in `m.json` excerpt; needs deeper check. If absent, easy to add (`clients.mindbodyonline.com` URL pattern, `MINDBODY` JS global, `healcode.com` script src for the embed).
+
+## 5. Recommendation — Option C (Hybrid)
+
+**Vendor enthec/webappanalyzer as a pinned snapshot, plus a thin local overlay.**
+
+Why not Option A (vendor everything as-is):
+- Bloat: 3.4 MB JSON across 27 files holds ~3,000 signatures, but only ~400–600 are relevant for local-biz lead qualification. Importing all of it slows Tier 0 startup and balloons the deny-list maintenance surface.
+- Update cadence drift: enthec ships changes daily. Pinning a snapshot and refreshing on a known cadence (monthly cron PR) is safer than tracking `main` blindly.
+
+Why not Option B (hand-curate from scratch):
+- Coverage check above shows enthec already nails 95%+ of what we need. Building this from zero is weeks of work that Wappalyzer's community has already done — and they'll keep doing it for free.
+
+Why not Option D (lean entirely on Lighthouse/Observatory):
+- PSI's built-in tech fingerprinter is shallow (~50 detections) compared to enthec's ~3,000. PSI won't tell us "this is Webflow" or "this is HubSpot Marketing Hub vs Sales Hub." Use those APIs to **augment**, not replace.
+
+Why Option C wins:
+- We get the day-one comprehensive coverage of A.
+- We get the precision and ownership of B for the 5–10 niche signatures Wappalyzer misses (Booksy, possibly Mindbody, GHL/HighLevel, GoHighLevel landers, ClickFunnels v2, niche local-biz CRMs).
+- We get the orthogonal evidence axes (perf/security/a11y) of D from free remote APIs.
+- License risk is contained: GPL-3.0 covers code derivative work; the JSON data files are arguably not "code" but conservative posture is to keep them in a clearly delineated `signals/wappalyzer_pack/` subtree, ship the upstream `LICENSE` alongside, and link to the source. We are not modifying and redistributing a binary — we are running the data behind a network service (Tier 0 deterministic evaluator), which under standard GPL interpretation is not a "distribution" event. **Confirm with counsel before shipping a self-hosted version to clients**, but for SaaS use the SaaS-loophole logic holds.
+
+## 6. Implementation notes for `logic-engine/`
+
+Drop in alongside the existing Tier 0 modules (`gatekeeper.py`, `deterministic_evaluator.py`):
+
+```
+logic-engine/
+  signals/
+    __init__.py
+    wappalyzer_pack/
+      LICENSE                 # vendored verbatim from enthec
+      VERSION                 # e.g. "enthec@a3f9c21 2026-04-17"
+      categories.json
+      technologies/
+        _.json a.json b.json ... z.json   # filtered subset
+      schema.json
+    overlay/
+      booksy.json             # our additions
+      mindbody.json
+      gohighlevel.json
+    matcher.py                # the actual fingerprinting engine
+    retire_js/
+      jsrepository.json       # Apache-2.0, no GPL constraint
+```
+
+`matcher.py` responsibilities:
+1. On import: load categories.json + all `technologies/*.json` + overlay JSONs into a single `dict[name -> Signature]`. Compile every regex pattern once with `re.IGNORECASE`. ~50 ms cold start for the full corpus, free thereafter.
+2. Public API:
+   ```python
+   def detect(raw_lead: RawLead) -> list[Detection]: ...
+   ```
+   where `Detection = (tech_name, category_ids, confidence, evidence_kind, matched_pattern)`. Iterate signatures × evidence sources (`raw_lead.script_srcs`, `raw_lead.stylesheet_hrefs`, `raw_lead.response_headers`, `raw_lead.raw_html`, `raw_lead.text_content`). Short-circuit on first hit per signature per evidence kind, accumulate confidence.
+3. Apply `implies` chains transitively (Shopify implies PHP; HubSpot CMS implies HubSpot).
+4. Return structured detections that downstream rule modules in `logic-engine/signals/rules/` can consume — e.g. "if `cats` includes 53 (CRM), set `lead.has_crm = True`"; "if any detection has `pricing: high`, raise budget signal."
+
+Curation step (one-time): write a 30-line script that walks `enthec/webappanalyzer/src/technologies/*.json` and **keeps only signatures whose `cats` intersect** our shortlist `{1, 6, 10, 31, 32, 41, 51, 52, 53, 62, 67, 72, 74, 75, 88, 92, 93, 110}`. Estimated trim: 3.4 MB → ~600 KB, ~3,000 → ~700 sigs. Re-run monthly via GitHub Action that opens a PR; human reviews diff.
+
+Remote API integration: add `signals/remote/psi.py` and `signals/remote/observatory.py` as Tier 0.5 (best-effort, soft-fail, ~3 s timeout). They run in parallel via `asyncio.gather` after the local matcher returns. Cache results in Postgres keyed by `(host, day)` to stay well under PSI's 25k/day limit (single GCP project handles ~700k unique hosts/month).
+
+Tests: snapshot-test the matcher against `tests/fixtures/raw_html/` samples for each major category. Add a CI guardrail that fails if an upstream snapshot bump removes a detection we depend on (Squarespace, Shopify, WordPress, HubSpot, Calendly, Mailchimp, Stripe, Cloudflare).
+
+---
+
+## Sources
+
+- enthec/webappanalyzer: https://github.com/enthec/webappanalyzer
+- HTTPArchive/wappalyzer: https://github.com/HTTPArchive/wappalyzer
+- enthec schema: https://raw.githubusercontent.com/enthec/webappanalyzer/main/schema.json
+- enthec categories: https://raw.githubusercontent.com/enthec/webappanalyzer/main/src/categories.json
+- WhatWeb: https://github.com/urbanadventurer/WhatWeb
+- retire.js: https://github.com/RetireJS/retire.js
+- CERN-CERT/WAD: https://github.com/CERN-CERT/WAD
+- py-wappalyzer (enthec-based Python loader reference): https://github.com/PigeonSec/py-wappalyzer
+- BuiltWith plans: https://builtwith.com/plans
+- BuiltWith free API: https://api.builtwith.com/free-api
+- Mozilla HTTP Observatory v2: https://developer.mozilla.org/en-US/observatory and https://github.com/mdn/mdn-http-observatory
+- PageSpeed Insights API: https://developers.google.com/speed/docs/insights/v5/get-started
+- SecurityHeaders.com API shutdown notice: https://securityheaders.com/api/
+- Hardenize (Red Sift): https://www.hardenize.com/
+- GPL-3.0 SaaS loophole reference: https://www.revenera.com/blog/software-composition-analysis/understanding-the-saas-loophole-in-gpl/


### PR DESCRIPTION
## Summary

Three research artifacts to support Phase 2 planning. Read-only research, no code.

- **phase1b-competitive-analysis.md** — 11-tool competitive audit (MapiLeads, Apollo, Cognism, Clay, Outscraper, Apify actors, PhantomBuster, Ocean.io, Persana, Lead Scrape, GoHighLevel)
- **phase1b-signature-db-evaluation.md** — open + commercial fingerprint DB evaluation (enthec/webappanalyzer, HTTPArchive fork, BuiltWith, Retire.js, PSI, Mozilla Observatory)
- **phase1b-recommendations.md** — synthesis with concrete answers to recon doc decisions #3 and #4

## Headline findings

1. **No competitor markets audited deterministic-first per-URL scoring.** The space is contact-DB-with-opaque-scoring (Apollo, Cognism), raw-scrape-with-no-scoring (Outscraper, MapiLeads), or workflow-canvas-where-user-builds-scoring (Clay, Persana). That's TraceFabric's positioning gap.
2. **Cost gap is concrete:** deterministic Tier 0 ~\$0.001/URL vs LLM-first scorers ~\$0.005-0.02/URL. 5-20x story for buyers running 10k+/month.
3. **enthec/webappanalyzer** is the de-facto living Wappalyzer fork. GPL-3.0, ~3,000 sigs, formal schema, owner publicly committed not to privatize. Core risk is GPL contamination — mitigate via process isolation.
4. **Wappalyzer is weak on local-biz SaaS** (Booksy, Mindbody, Toast, ServiceTitan). That's where curated signatures earn their keep.

## Recommendations (the actionable part)

**Decision #3 — Signature pack source: Hybrid**
- Vendor enthec/webappanalyzer (filtered to ~700 relevant sigs, GPL-isolated)
- Vendor retire.js (Apache-2.0, no GPL exposure)
- Curate ~30-50 local-biz signatures (booking, restaurant POS, salon software, contractor CRMs, review widgets)
- Plug Google PSI + Mozilla Observatory as free remote orthogonal axes
- Skip: BuiltWith (\$295+/mo), SecurityHeaders.com (shutting down), pure-curate option (3000-week effort to reinvent)

**Decision #4 — Weights source: YAML now, XGBoost parallel later**
- YAML weights per campaign in version-controlled files now
- The auditable rubric IS the differentiation per competitive research
- After ≥500 teacher-labeled rows, train XGBoost as a *parallel* signal, never replace YAML
- Discrepancy between YAML and XGBoost becomes a useful QA signal

## What this PR does NOT change

- No code changes
- No DB schema changes
- No protobuf changes
- No behavior changes to the running pipeline

## Suggested Phase 2 starter scope (pending greenlight)

3 sprints (~5 days total):
- Sprint 1: Vendor sigs, build matcher engine, snapshot tests
- Sprint 2: Local-biz curation, PSI/Observatory integration, YAML weight schema
- Sprint 3: Validate against benchmark URLs, tune weights

All behind a \`signals_v2\` feature flag — existing pipeline untouched until cutover.

## Test plan

- [ ] Reviewer reads phase1b-recommendations.md (the synthesis)
- [ ] If pressed for time, just read that one doc — full research is supporting evidence
- [ ] Confirm or override the hybrid signature pack recommendation
- [ ] Confirm or override the YAML-now / XGBoost-later recommendation
- [ ] Provide tier priority + 20+20 benchmark URLs whenever ready (those don't block this PR)

## Related

- Builds on #16 (Phase 1 recon) which identified the data flow gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new research-only markdown docs with no runtime/code, schema, or dependency changes.
> 
> **Overview**
> Adds three Phase 1b research docs in `docs/research/` to guide upcoming Phase 2 work.
> 
> The new material includes a competitive analysis of deterministic vs LLM-based signal extraction in lead tools, an evaluation of tech-fingerprinting signature databases (with licensing considerations), and a synthesis recommending a hybrid approach (vendored Wappalyzer-class + Retire.js + small local-biz overlay) plus YAML-based scoring weights now with a later ML path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548b10baa5e01704ae4d151a0acf3060e93cb86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->